### PR TITLE
Implementing custom cache key in CacheManager

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -24,6 +24,14 @@ CacheManager.config = {
   cacheLimit: 1024 * 1024 * 256, // ~256MB
   sourceAnimationDuration: 1000,
   thumbnailAnimationDuration: 1000,
+  getCustomCacheKey: (source: string) => {
+    // Remove params from the URL for chacing images (useful for caching images from Amazons S3 bucket and etc)
+    let newCacheKey = source;
+    if (source.includes('?')) {
+      newCacheKey = source.substring(0, source.lastIndexOf('?'));
+    }
+    return newCacheKey;
+  }
 };
 
 const prefetchImage =

--- a/src/CacheManager.ts
+++ b/src/CacheManager.ts
@@ -200,6 +200,10 @@ const getCacheEntry = async (
   cacheKey: string,
   maxAge?: number | undefined
 ): Promise<{ exists: boolean; path: string; tmpPath: string }> => {
+  let newCacheKey = cacheKey;
+  if (CacheManager.config.getCustomCacheKey) {
+    newCacheKey = CacheManager.config.getCustomCacheKey(cacheKey);
+  }
   const filename = cacheKey.substring(
     cacheKey.lastIndexOf('/'),
     cacheKey.indexOf('?') === -1 ? cacheKey.length : cacheKey.indexOf('?')
@@ -208,7 +212,7 @@ const getCacheEntry = async (
     filename.indexOf('.') === -1
       ? '.jpg'
       : filename.substring(filename.lastIndexOf('.'));
-  const sha = SHA1(cacheKey);
+  const sha = SHA1(newCacheKey);
   const path = `${CacheManager.config.baseDir}${sha}${ext}`;
   const tmpPath = `${CacheManager.config.baseDir}${sha}-${uniqueId()}${ext}`;
   // TODO: maybe we don't have to do this every time

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -69,4 +69,5 @@ export interface Config {
   cacheLimit: number;
   sourceAnimationDuration: number;
   thumbnailAnimationDuration: number;
+  getCustomCacheKey?: (source: string) => string;
 }


### PR DESCRIPTION
Resolving an issue #29 
Possibility to implement custom cache key in the library.

It can be useful in many cases, such as using Amazons S3 bucket for image storage and etc, where it could be hard to cache an image due to different URL params (access tokens) in every new request for the same image.

I've tried to resolve this issue in the pull request.
I'll appreciate your feedback to my contribution.

Thank you