### PR TITLE
fix: use options for thumbnails & support token refresh

### DIFF
--- a/src/CacheManager.ts
+++ b/src/CacheManager.ts
@@ -103,7 +103,7 @@ export default class CacheManager {
     noCache?: boolean,
     maxAge?: number
   ): CacheEntry {
-    if (!CacheManager.entries[source]) {
+    if (!CacheManager.entries[source] || CacheManager.entries[source].options?.headers?.Authorization !== options?.headers?.Authorization) {
       CacheManager.entries[source] = new CacheEntry(
         source,
         options,

--- a/src/CachedImage.tsx
+++ b/src/CachedImage.tsx
@@ -59,7 +59,7 @@ function useStateIfMounted<S>(
 const CachedImage = (props: IProps & typeof defaultProps) => {
   const [error, setError] = useStateIfMounted<boolean>(false);
   const [uri, setUri] = useStateIfMounted<string | undefined>(undefined);
-  const { source: propsSource } = props;
+  const { source: propsSource, options: propsOptions } = props;
   const [currentSource, setCurrentSource] = React.useState<string>(propsSource);
 
   const animatedImage = useSharedValue(0);
@@ -90,7 +90,7 @@ const CachedImage = (props: IProps & typeof defaultProps) => {
       resetAnimations();
     }
     /* eslint-disable react-hooks/exhaustive-deps */
-  }, [propsSource, uri]);
+  }, [propsSource, uri, propsOptions]);
 
   const load = async ({
     maxAge,
@@ -216,7 +216,7 @@ const CachedImage = (props: IProps & typeof defaultProps) => {
           blurRadius={blurRadius || CacheManager.config.blurRadius}
           onLoad={onThumbnailLoad}
           resizeMode={resizeMode || 'contain'}
-          source={{ uri: thumbnailSource }}
+          source={{ uri: thumbnailSource, ...propsOptions }}
           style={[style, thumbnailSourceStyle]}
         />
       )}


### PR DESCRIPTION
- **Use options for thumbnails as well** 
Options property are used only for source image. So, if you have any required header or option to get thumbnail images from whatever backend you're using, it'll silently fail.

-  **Support refresh on token update**
Cache Manager is being instanced once and only registering uris and options by source URL. So, if you have the same URL being called from different places across the app, you may face at some point that your images won't load since they have been stored by URL (which is the same) and with the first option that Cache Manager received; so you may already got the idea but to summarize you're not getting your images because the token that Cache Manager is using has expired and it's not being updated.