### PR TITLE
fix: check if path exist when clearing

### DIFF
--- a/src/CacheManager.ts
+++ b/src/CacheManager.ts
@@ -120,12 +120,14 @@ export default class CacheManager {
   }
 
   static async clearCache(): Promise<void> {
-    const files = await FileSystem.ls(CacheManager.config.baseDir);
-    for (const file of files) {
-      try {
-        await FileSystem.unlink(`${CacheManager.config.baseDir}${file}`);
-      } catch (e) {
-        console.log(`error while clearing images cache, error: ${e}`);
+    if (await FileSystem.exists(CacheManager.config.baseDir)) {
+      const files = await FileSystem.ls(CacheManager.config.baseDir);
+      for (const file of files) {
+        try {
+          await FileSystem.unlink(`${CacheManager.config.baseDir}${file}`);
+        } catch (e) {
+          console.log(`error while clearing images cache, error: ${e}`);
+        }
       }
     }
   }


### PR DESCRIPTION
If there are no images that were cached and as result no directory created, ["Failed to list" error is thrown](https://github.com/alpha0010/react-native-file-access/blob/7179426e701fa6e54bda6c2a753cfe31a4a08293/ios/FileAccess.swift#L225) when calling CacheManager.clearCache(). As a fix, we first check if the path exists and only then do we remove the images
