### PR TITLE
fix: catch FileSystem.fetch network offline error

### DIFF
--- a/src/CacheManager.ts
+++ b/src/CacheManager.ts
@@ -62,15 +62,22 @@ export class CacheEntry {
     }
 
     if (source != null) {
-      const result = await FileSystem.fetch(source, {
-        path: tmpPath,
-        ...options,
-      });
-      // If the image download failed, we don't cache anything
-      if (result && result.status !== 200) {
+      try {
+        const result = await FileSystem.fetch(source, {
+          path: tmpPath,
+          ...options,
+        });
+        // If the image download failed, we don't cache anything
+        if (result && result.status !== 200) {
+          this.downloadPromise = undefined;
+          return undefined;
+        }
+      } catch (e) {
+        console.log("FileSystem.fetch meet some trouble: " + (e instanceof Error ? e.message : 'unknown'))
         this.downloadPromise = undefined;
         return undefined;
       }
+
       await FileSystem.mv(tmpPath, path);
       if (CacheManager.config.cacheLimit) {
         await CacheManager.pruneCache();


### PR DESCRIPTION
if `FileSystem.fetch` meet network error（e.g. phone get weak signal when inside metro）, it with throw error instead of return response

how to repoduct: prefetch multiple image, switch network to offline, switch to online after wait a moment, re prefetch always return error `Failed to fetch 'url'. The Internet connection appears to be offline.`