### PR TITLE
Fix global config animation durations being ignored if props are not set

### DIFF
--- a/src/CachedImage.tsx
+++ b/src/CachedImage.tsx
@@ -137,11 +137,9 @@ const CachedImage = (props: IProps & typeof defaultProps) => {
     animatedLoadingImage.value = withTiming(0, {}, () => {
       animatedThumbnailImage.value = withTiming(1, {
         duration:
-          props.thumbnailAnimationDuration === 0
-            ? 0
-            : props.thumbnailAnimationDuration ||
-              CacheManager?.config?.thumbnailAnimationDuration ||
-              100,
+          props.thumbnailAnimationDuration ??
+          CacheManager?.config?.thumbnailAnimationDuration ??
+          100,
       });
     });
   };
@@ -159,11 +157,9 @@ const CachedImage = (props: IProps & typeof defaultProps) => {
     }
     animatedImage.value = withTiming(1, {
       duration:
-        props.sourceAnimationDuration === 0
-          ? 0
-          : props.sourceAnimationDuration ||
-            CacheManager?.config?.sourceAnimationDuration ||
-            100,
+        props.sourceAnimationDuration ??
+        CacheManager?.config?.sourceAnimationDuration ??
+        100,
     });
   };
 


### PR DESCRIPTION
This will fix an issue where if the animation durations are set in the global config, they are ignored unless an explicit prop is passed.

The problem is that the current implementation does a simple logical OR comparison against the config value if the prop value is undefined, meaning it falls back to 100 ms for the duration of the animation.

Sample code that used to cause the issue:

```
CacheManager.config = {
  baseDir: `${Dirs.CacheDir}/images_cache/`,
  blurRadius: 0,
  cacheLimit: 1024 * 1024 * 1024,
  maxRetries: 2,
  retryDelay: 1000,
  sourceAnimationDuration: 0,
  thumbnailAnimationDuration: 0,
};
```

Component usage:

```
        <CachedImage
          source={imageUrl}
          style={{
            width: '100%',
            height: '100%',
          }}
        />
```

The fix is to just use the Nullish coalescing operator to compare the values rather than only checking if props set it to zero. So now the priority is props value -> config value -> default (100) as intended.

I've already tested this change in my current project, as well as the example project and it works correctly as far as I can see now.